### PR TITLE
Color enum serialization/deserialization

### DIFF
--- a/src/main/scala/com/github/pjfanning/enum/deser/EnumDeserializerModule.scala
+++ b/src/main/scala/com/github/pjfanning/enum/deser/EnumDeserializerModule.scala
@@ -68,8 +68,10 @@ private case class EnumDeserializer[T <: Enum](clazz: Class[T]) extends StdDeser
         Some(clazz)
       }
       objectClassOption.flatMap { objectClass =>
-        EnumDeserializerShared.tryValueOf(objectClass, text)
-          .orElse(EnumDeserializerShared.matchBasedOnOrdinal(objectClass, text))
+        Try {
+          EnumDeserializerShared.tryValueOf(objectClass, text)
+            .orElse(EnumDeserializerShared.matchBasedOnOrdinal(objectClass, text))
+        }.toOption.flatten
       }.asInstanceOf[Option[T]]
     }
     result.getOrElse(throw new IllegalArgumentException(s"Failed to create Enum instance for ${p.getValueAsString}"))
@@ -86,8 +88,10 @@ private case class EnumKeyDeserializer[T <: Enum](clazz: Class[T]) extends KeyDe
       Some(clazz)
     }
     val result = objectClassOption.flatMap { objectClass =>
-      EnumDeserializerShared.tryValueOf(objectClass, key)
-        .orElse(EnumDeserializerShared.matchBasedOnOrdinal(objectClass, key))
+      Try {
+        EnumDeserializerShared.tryValueOf(objectClass, key)
+          .orElse(EnumDeserializerShared.matchBasedOnOrdinal(objectClass, key))
+      }.toOption.flatten
     }
     val enumResult = result.getOrElse(throw new IllegalArgumentException(s"Failed to create Enum instance for $key"))
     enumResult.asInstanceOf[AnyRef]

--- a/src/test/scala/com/github/pjfanning/enum/EnumDeserializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enum/EnumDeserializerSpec.scala
@@ -22,6 +22,13 @@ class EnumDeserializerSpec extends AnyWordSpec with Matchers {
       val red = s""""${ColorEnum.Red}""""
       mapper.readValue(red, classOf[ColorEnum]) shouldEqual ColorEnum.Red
     }
+    "fail deserialization of invalid ColorEnum" in {
+      val mapper = JsonMapper.builder().addModule(EnumModule).build()
+      val json = s""""xyz""""
+      intercept[IllegalArgumentException] {
+        mapper.readValue(json, classOf[ColorEnum])
+      }
+    }
     "deserialize Colors" in {
       val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(EnumModule).build()
       val colors = Colors(Set(ColorEnum.Red, ColorEnum.Green))

--- a/src/test/scala/com/github/pjfanning/enum/adt/AdtDeserializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enum/adt/AdtDeserializerSpec.scala
@@ -13,5 +13,18 @@ class AdtDeserializerSpec extends AnyWordSpec with Matchers {
       val red = s""""${Color.Red}""""
       mapper.readValue(red, classOf[Color]) shouldEqual Color.Red
     }
+    "fail deserialization of invalid Color ADT" in {
+      val mapper = JsonMapper.builder().addModule(EnumModule).build()
+      val json = s""""xyz""""
+      intercept[IllegalArgumentException] {
+        mapper.readValue(json, classOf[Color])
+      }
+    }
+    "deserialize ColorSet" in {
+      val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(EnumModule).build()
+      val colors = ColorSet(Set(Color.Red, Color.Green))
+      val json = mapper.writeValueAsString(colors)
+      mapper.readValue(json, classOf[ColorSet]) shouldEqual colors
+    }
   }
 }

--- a/src/test/scala/com/github/pjfanning/enum/adt/AdtDeserializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enum/adt/AdtDeserializerSpec.scala
@@ -1,0 +1,17 @@
+package com.github.pjfanning.`enum`.adt
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.github.pjfanning.`enum`.EnumModule
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AdtDeserializerSpec extends AnyWordSpec with Matchers {
+  "EnumModule" should {
+    "deserialize Color ADT" in {
+      val mapper = JsonMapper.builder().addModule(EnumModule).build()
+      val red = s""""${Color.Red}""""
+      mapper.readValue(red, Color.Red.getClass) shouldEqual Color.Red
+    }
+  }
+}

--- a/src/test/scala/com/github/pjfanning/enum/adt/AdtDeserializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enum/adt/AdtDeserializerSpec.scala
@@ -11,7 +11,7 @@ class AdtDeserializerSpec extends AnyWordSpec with Matchers {
     "deserialize Color ADT" in {
       val mapper = JsonMapper.builder().addModule(EnumModule).build()
       val red = s""""${Color.Red}""""
-      mapper.readValue(red, Color.Red.getClass) shouldEqual Color.Red
+      mapper.readValue(red, classOf[Color]) shouldEqual Color.Red
     }
   }
 }

--- a/src/test/scala/com/github/pjfanning/enum/adt/AdtSerializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enum/adt/AdtSerializerSpec.scala
@@ -25,4 +25,3 @@ class AdtSerializerSpec extends AnyWordSpec with Matchers {
     }
   }
 }
-

--- a/src/test/scala/com/github/pjfanning/enum/adt/AdtSerializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enum/adt/AdtSerializerSpec.scala
@@ -1,0 +1,28 @@
+package com.github.pjfanning.`enum`.adt
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.github.pjfanning.`enum`.EnumModule
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AdtSerializerSpec extends AnyWordSpec with Matchers {
+  "EnumModule" should {
+    "serialize Color ADT" in {
+      val mapper = JsonMapper.builder().addModule(EnumModule).build()
+      mapper.writeValueAsString(Color.Red) shouldEqual (s""""${Color.Red}"""")
+    }
+    "serialize Color.Mix" in {
+      val mapper = JsonMapper.builder().addModule(EnumModule).build()
+      mapper.writeValueAsString(Color.Mix(0x4488FF)) shouldEqual (s""""Mix(4491519)"""")
+    }
+    "serialize ColorSet" in {
+      val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(EnumModule).build()
+      val json = mapper.writeValueAsString(ColorSet(Set(Color.Red, Color.Green)))
+      json should startWith("""{"set":[""")
+      json should include(""""Red"""")
+      json should include(""""Green"""")
+    }
+  }
+}
+

--- a/src/test/scala/com/github/pjfanning/enum/adt/Color.scala
+++ b/src/test/scala/com/github/pjfanning/enum/adt/Color.scala
@@ -1,0 +1,11 @@
+package com.github.pjfanning.`enum`.adt
+
+import com.github.pjfanning.`enum`.ColorEnum
+
+enum Color(val rgb: Int):
+  case Red   extends Color(0xFF0000)
+  case Green extends Color(0x00FF00)
+  case Blue  extends Color(0x0000FF)
+  case Mix(mix: Int) extends Color(mix)
+
+case class ColorSet(set: Set[Color])  


### PR DESCRIPTION
https://github.com/FasterXML/jackson-module-scala/issues/615

So far, only simple enumerations were supported, eg
```
enum Color:
  case Red, Green, Blue
```

This PR adds support for examples like:
```
enum Color(val rgb: Int):
  case Red   extends Color(0xFF0000)
  case Green extends Color(0x00FF00)
  case Blue  extends Color(0x0000FF)
```

It also tidies up the exception handling so that when deserializing invalid enum values, an IllegalArgumentException will be thrown. 